### PR TITLE
fix: navbar fixed maken #107 & #50

### DIFF
--- a/src/lib/components/Navdetailpagina.svelte
+++ b/src/lib/components/Navdetailpagina.svelte
@@ -19,17 +19,20 @@
 </div>
 
 <style>
+
   /* sidebar & slide in*/
   .sidebar {
     display: none;
-    min-height: auto;
     width: clamp(180px, 20vw, 260px);
     background: var(--color-neutral);
     padding: clamp(12px, 2vw, 24px);
-    border-right: 1px solid #ddd;
+    /* border-right: 1px solid #ddd; */
     opacity: 0;
-    transform: translateX(-12px);
+    transform: translateX(-142px);
     animation: sidebar-in 400ms ease-out forwards;
+    position: sticky;
+    top: 15vh; /*De navbar is lager geplaatst om niet met de logo to overlappen */
+    height: 5vh;
   }
 
   @keyframes sidebar-in {
@@ -78,6 +81,7 @@
   }
 
   /* Zorgt dat de lijst soepel openklapt */
+
   details ul {
     margin: clamp(4px, 1vh, 8px) 0 0 clamp(15px, 2vw, 25px);
     list-style: none;
@@ -96,6 +100,7 @@
   }
 
   /* link style + hoverbar */
+
   details a {
     display: block;
     margin: clamp(4px, 1vh, 8px) 0;
@@ -109,7 +114,6 @@
     transition: transform 160ms ease-out;
   }
 
-  /* slideover bar */
   details a::before {
     content: "";
     position: absolute;
@@ -131,7 +135,6 @@
     opacity: 1;
   }
 
-  /* tekst schuift iets naar rechts bij hover */
   details a:hover {
     transform: translateX(4px);
   }


### PR DESCRIPTION
## What does this change?

Resolves issue #107 & #50  
Bij het scrollen verschoof de navbar naar boven, om dat te voorkomen heb ik het volgende gedaan.

- Position: Fixed toegevoegd
- Top van 15v toegevoegd om de navbar niet te laten overlappen met de logo linksboven
- De schuif animatie bij het refreshen verhoogt voor een betere user experience
- Border weg gehaald voor een cleaner look

[Livesite](https://emibazo.netlify.app)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [x] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images

Het ziet er nu zo uit:

https://github.com/user-attachments/assets/3e2b260c-741c-4352-8f80-db9002274a87


## How to review
- Open de branch lokaal.  
-  Test of alle bovengenoemde animaties werken.  
- Controleer of je bij het testen een bug tegenkomt
