### PR TITLE
lemma fix?

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
 [build]
 	command = "npm run build"
 	publish = "build"
+
+[functions]
+	node_bundler = "esbuild"

--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -12,7 +12,7 @@
 
     <div class="links-nav-container" aria-hidden="true">
         <a href="/nieuwsbriefhehre">Nieuwsbrief</a>
-        <a href="/overons">Over ons</a>
+        <a href="/overons">Wie is wie</a>
         <a href="/helpgewegwg">Help center</a>
         <a href="/kaart">Kaart</a>
         <a href="/wikiwegwge">Wiki</a>

--- a/src/routes/kaart/+page.server.js
+++ b/src/routes/kaart/+page.server.js
@@ -1,29 +1,11 @@
 export const prerender = false;
 
-// Helper: fetch with timeout
-async function fetchWithTimeout(url, timeout = 10000) {
-    const controller = new AbortController();
-    const id = setTimeout(() => controller.abort(), timeout);
-    try {
-        const res = await fetch(url, {
-            signal: controller.signal,
-            headers: {
-                Accept: 'application/json',
-                'User-Agent': 'SvelteKit-App',
-            },
-        });
-        return res;
-    } finally {
-        clearTimeout(id);
-    }
-}
-
-export async function load() {
+export async function load({ fetch }) {
     const DIRECTUS_BASE = 'https://fdnd-agency.directus.app';
     const link = `${DIRECTUS_BASE}/items/emibazo_lemma`;
 
     try {
-        const res = await fetchWithTimeout(link, 10000); // 10s timeout
+        const res = await fetch(link);
 
         if (!res.ok) {
             // eslint-disable-next-line no-console

--- a/src/routes/kaart/+page.server.js
+++ b/src/routes/kaart/+page.server.js
@@ -1,11 +1,29 @@
 export const prerender = false;
 
-export async function load({ fetch }) {
+// Helper: fetch with timeout
+async function fetchWithTimeout(url, timeout = 10000) {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeout);
+    try {
+        const res = await fetch(url, {
+            signal: controller.signal,
+            headers: {
+                Accept: 'application/json',
+                'User-Agent': 'SvelteKit-App',
+            },
+        });
+        return res;
+    } finally {
+        clearTimeout(id);
+    }
+}
+
+export async function load() {
     const DIRECTUS_BASE = 'https://fdnd-agency.directus.app';
     const link = `${DIRECTUS_BASE}/items/emibazo_lemma`;
 
     try {
-        const res = await fetch(link);
+        const res = await fetchWithTimeout(link, 10000); // 10s timeout
 
         if (!res.ok) {
             // eslint-disable-next-line no-console

--- a/src/routes/kaart/+page.server.js
+++ b/src/routes/kaart/+page.server.js
@@ -33,7 +33,8 @@ export async function load({ fetch }) {
         return { mapAddresses };
     } catch (error) {
         // Als het fout gaat, log het de fout.
-        error('Error fetching Directus items', error);
+        // eslint-disable-next-line no-console
+        console.error('Error fetching Directus items', error);
         return { mapAddresses: [] };
     }
 }

--- a/src/routes/kaart/+page.server.js
+++ b/src/routes/kaart/+page.server.js
@@ -5,12 +5,12 @@ async function fetchWithTimeout(url, timeout = 10000) {
     const controller = new AbortController();
     const id = setTimeout(() => controller.abort(), timeout);
     try {
-        const res = await fetch(url, { 
+        const res = await fetch(url, {
             signal: controller.signal,
             headers: {
-                'Accept': 'application/json',
-                'User-Agent': 'SvelteKit-App'
-            }
+                Accept: 'application/json',
+                'User-Agent': 'SvelteKit-App',
+            },
         });
         return res;
     } finally {

--- a/src/routes/kaart/+page.server.js
+++ b/src/routes/kaart/+page.server.js
@@ -1,17 +1,22 @@
 // Link van de directus API ophalen
-export async function load({ fetch }) {
+export const prerender = false;
+
+export async function load() {
     const DIRECTUS_BASE = 'https://fdnd-agency.directus.app';
     const link = `${DIRECTUS_BASE}/items/emibazo_lemma`;
 
     try {
-        // fetch() haalt data op uit de API. Daarna word het omgezet in JSON zodat wij het kunnen gebruiken.
-        const mapResponse = await fetch(link);
+        const res = await fetch(link);
 
-        if (!mapResponse.ok) {
-            throw new Error(`Directus API failed: ${mapResponse.status}`);
+        // If API fails, return safe empty array instead of throwing
+        if (!res.ok) {
+            // eslint-disable-next-line no-console
+            console.error(`Directus API error: ${res.status}`);
+            return { mapAddresses: [] };
         }
-        const mapResponseJSON = await mapResponse.json();
-        const items = mapResponseJSON.data ?? [];
+
+        const json = await res.json();
+        const items = json.data ?? [];
 
         // Voor elk item worden alleen de benodigde velden meegenomen
         const mapAddresses = items.map((it) => ({

--- a/src/routes/kaart/+page.server.js
+++ b/src/routes/kaart/+page.server.js
@@ -1,14 +1,30 @@
-// Link van de directus API ophalen
 export const prerender = false;
+
+// Helper: fetch with timeout
+async function fetchWithTimeout(url, timeout = 10000) {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeout);
+    try {
+        const res = await fetch(url, { 
+            signal: controller.signal,
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'SvelteKit-App'
+            }
+        });
+        return res;
+    } finally {
+        clearTimeout(id);
+    }
+}
 
 export async function load() {
     const DIRECTUS_BASE = 'https://fdnd-agency.directus.app';
     const link = `${DIRECTUS_BASE}/items/emibazo_lemma`;
 
     try {
-        const res = await fetch(link);
+        const res = await fetchWithTimeout(link, 10000); // 10s timeout
 
-        // If API fails, return safe empty array instead of throwing
         if (!res.ok) {
             // eslint-disable-next-line no-console
             console.error(`Directus API error: ${res.status}`);
@@ -18,26 +34,24 @@ export async function load() {
         const json = await res.json();
         const items = json.data ?? [];
 
-        // Voor elk item worden alleen de benodigde velden meegenomen
         const mapAddresses = items.map((it) => ({
             id: it.id,
             slug: it.slug,
             title: it.title,
-            street: it.address,
-            summary: it.summary,
-            body: it.body,
-            posterimage: it.posterimage,
-            posterimage_url: it.posterimage,
-            map: it.geolocation,
-            date_created: it.date_created,
-            date_updated: it.date_updated,
+            street: it.address ?? '',
+            summary: it.summary ?? '',
+            body: it.body ?? '',
+            posterimage: it.posterimage ?? null,
+            posterimage_url: it.posterimage ?? null,
+            map: it.geolocation ?? null,
+            date_created: it.date_created ?? null,
+            date_updated: it.date_updated ?? null,
         }));
 
         return { mapAddresses };
-    } catch (error) {
-        // Als het fout gaat, log het de fout.
+    } catch (err) {
         // eslint-disable-next-line no-console
-        console.error('Error fetching Directus items', error);
+        console.error('Error fetching Directus items', err);
         return { mapAddresses: [] };
     }
 }

--- a/src/routes/kaart/+page.server.js
+++ b/src/routes/kaart/+page.server.js
@@ -6,29 +6,27 @@ export async function load({ fetch }) {
     try {
         // fetch() haalt data op uit de API. Daarna word het omgezet in JSON zodat wij het kunnen gebruiken.
         const mapResponse = await fetch(link);
+
+        if (!mapResponse.ok) {
+            throw new Error(`Directus API failed: ${mapResponse.status}`);
+        }
         const mapResponseJSON = await mapResponse.json();
-        const items = mapResponseJSON.data;
+        const items = mapResponseJSON.data ?? [];
 
         // Voor elk item worden alleen de benodigde velden meegenomen
-        const mapAddresses = items.map((it) => {
-            const posterimage_id = it.posterimage;
-            const posterimage_url = posterimage_id;
-            const geol = it.geolocation;
-
-            return {
-                id: it.id,
-                slug: it.slug,
-                title: it.title,
-                street: it.address,
-                summary: it.summary,
-                body: it.body,
-                posterimage: posterimage_id,
-                posterimage_url,
-                map: geol,
-                date_created: it.date_created,
-                date_updated: it.date_updated,
-            };
-        });
+        const mapAddresses = items.map((it) => ({
+            id: it.id,
+            slug: it.slug,
+            title: it.title,
+            street: it.address,
+            summary: it.summary,
+            body: it.body,
+            posterimage: it.posterimage,
+            posterimage_url: it.posterimage,
+            map: it.geolocation,
+            date_created: it.date_created,
+            date_updated: it.date_updated,
+        }));
 
         return { mapAddresses };
     } catch (error) {

--- a/src/routes/overons/+page.server.js
+++ b/src/routes/overons/+page.server.js
@@ -1,22 +1,9 @@
 export const prerender = false;
 
-// Helper: fetch with timeout
-async function fetchWithTimeout(url, timeout = 5000) {
-    const controller = new AbortController();
-    const id = setTimeout(() => controller.abort(), timeout);
+export async function load({ fetch }) {
     try {
-        const res = await fetch(url, { signal: controller.signal });
-        return res;
-    } finally {
-        clearTimeout(id);
-    }
-}
-
-export async function load() {
-    try {
-        const res = await fetchWithTimeout(
+        const res = await fetch(
             'https://fdnd-agency.directus.app/items/emibazo_persoon?fields=*',
-            5000,
         );
 
         if (!res.ok) {

--- a/src/routes/overons/+page.server.js
+++ b/src/routes/overons/+page.server.js
@@ -16,7 +16,7 @@ export async function load() {
     try {
         const res = await fetchWithTimeout(
             'https://fdnd-agency.directus.app/items/emibazo_persoon?fields=*',
-            5000
+            5000,
         );
 
         if (!res.ok) {

--- a/src/routes/overons/+page.server.js
+++ b/src/routes/overons/+page.server.js
@@ -1,9 +1,22 @@
 export const prerender = false;
 
-export async function load({ fetch }) {
+// Helper: fetch with timeout
+async function fetchWithTimeout(url, timeout = 5000) {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeout);
     try {
-        const res = await fetch(
+        const res = await fetch(url, { signal: controller.signal });
+        return res;
+    } finally {
+        clearTimeout(id);
+    }
+}
+
+export async function load() {
+    try {
+        const res = await fetchWithTimeout(
             'https://fdnd-agency.directus.app/items/emibazo_persoon?fields=*',
+            5000,
         );
 
         if (!res.ok) {

--- a/src/routes/overons/+page.server.js
+++ b/src/routes/overons/+page.server.js
@@ -1,11 +1,35 @@
+export const prerender = false;
+
+// Helper: fetch with timeout
+async function fetchWithTimeout(url, timeout = 5000) {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeout);
+    try {
+        const res = await fetch(url, { signal: controller.signal });
+        return res;
+    } finally {
+        clearTimeout(id);
+    }
+}
+
 export async function load() {
-    const res = await fetch(
-        'https://fdnd-agency.directus.app/items/emibazo_persoon?fields=*',
-    );
+    try {
+        const res = await fetchWithTimeout(
+            'https://fdnd-agency.directus.app/items/emibazo_persoon?fields=*',
+            5000
+        );
 
-    const json = await res.json();
+        if (!res.ok) {
+            // eslint-disable-next-line no-console
+            console.error(`Directus API error: ${res.status}`);
+            return { members: [] };
+        }
 
-    return {
-        members: json.data ?? [],
-    };
+        const json = await res.json();
+        return { members: json.data ?? [] };
+    } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('SSR fetch failed for over-ons:', err);
+        return { members: [] };
+    }
 }

--- a/src/routes/wiki/[slug]/+page.server.js
+++ b/src/routes/wiki/[slug]/+page.server.js
@@ -1,26 +1,24 @@
 import { error } from '@sveltejs/kit';
-export const ssr = false;
-export const prerender = false;
 
-export async function load({ params }) {
-    const lemmaSlug = params.slug;
 
-    const url =
-        `https://fdnd-agency.directus.app/items/emibazo_lemma` +
-        `?filter[slug][_eq]=${encodeURIComponent(lemmaSlug)}`;
-
+export async function load({ params, fetch }) {
     try {
+        const lemmaSlug = params.slug;
+
+        const url =
+            `https://fdnd-agency.directus.app/items/emibazo_lemma` +
+            `?filter[slug][_eq]=${encodeURIComponent(lemmaSlug)}`;
+
         const response = await fetch(url);
 
-        // If Directus itself fails → real server problem
         if (!response.ok) {
-            throw error(response.status, 'Failed to fetch API');
+            throw error(500, 'Failed to fetch API');
         }
 
         const json = await response.json();
-        const lemma = json.data?.[0] ?? null;
+        const lemma = json.data?.[0];
 
-        // Proper 404 (allowed — does NOT crash SSR)
+        // ✅ handle missing slug properly
         if (!lemma) {
             throw error(404, 'Lemma not found');
         }
@@ -32,24 +30,14 @@ export async function load({ params }) {
                 title: lemma.title,
                 body: lemma.body,
                 address: lemma.address,
-                bouwjaar: lemma.bouwjaar
-            }
+                bouwjaar: lemma.bouwjaar,
+            },
         };
-
     } catch (err) {
-        // IMPORTANT:
-        // If it's already a SvelteKit HTTP error, rethrow it
-        if (err?.status) {
-            throw err;
-        }
-
         // eslint-disable-next-line no-console
-        console.error('Directus fetch failed:', err);
+        console.error('Error fetching lemma from API:', err);
 
-        // Instead of crashing SSR with 500,
-        // return safe fallback data
-        return {
-            lemma: null
-        };
+        // show proper error page instead of 500 crash
+        throw error(500, 'Server error while loading lemma');
     }
 }

--- a/src/routes/wiki/[slug]/+page.server.js
+++ b/src/routes/wiki/[slug]/+page.server.js
@@ -5,12 +5,12 @@ async function fetchWithTimeout(url, timeout = 10000) {
     const controller = new AbortController();
     const id = setTimeout(() => controller.abort(), timeout);
     try {
-        const res = await fetch(url, { 
+        const res = await fetch(url, {
             signal: controller.signal,
             headers: {
-                'Accept': 'application/json',
-                'User-Agent': 'SvelteKit-App'
-            }
+                Accept: 'application/json',
+                'User-Agent': 'SvelteKit-App',
+            },
         });
         return res;
     } finally {
@@ -27,7 +27,7 @@ export async function load({ params }) {
 
         if (!res.ok) {
             // SSR-safe logging
-              // eslint-disable-next-line no-console
+            // eslint-disable-next-line no-console
             console.error(`Directus API error: ${res.status}`);
             return { lemma: null };
         }
@@ -49,7 +49,7 @@ export async function load({ params }) {
         };
     } catch (err) {
         // SSR-safe logging
-         // eslint-disable-next-line no-console
+        // eslint-disable-next-line no-console
         console.error('SSR fetch failed:', err);
         return { lemma: null };
     }

--- a/src/routes/wiki/[slug]/+page.server.js
+++ b/src/routes/wiki/[slug]/+page.server.js
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-
+export const ssr = false;
 export const prerender = false;
 
 export async function load({ params }) {

--- a/src/routes/wiki/[slug]/+page.server.js
+++ b/src/routes/wiki/[slug]/+page.server.js
@@ -1,29 +1,11 @@
 export const prerender = false;
 
-// Helper: fetch with timeout
-async function fetchWithTimeout(url, timeout = 10000) {
-    const controller = new AbortController();
-    const id = setTimeout(() => controller.abort(), timeout);
-    try {
-        const res = await fetch(url, {
-            signal: controller.signal,
-            headers: {
-                Accept: 'application/json',
-                'User-Agent': 'SvelteKit-App',
-            },
-        });
-        return res;
-    } finally {
-        clearTimeout(id);
-    }
-}
-
-export async function load({ params }) {
+export async function load({ params, fetch }) {
     const lemmaSlug = params.slug;
     const url = `https://fdnd-agency.directus.app/items/emibazo_lemma?filter[slug][_eq]=${encodeURIComponent(lemmaSlug)}`;
 
     try {
-        const res = await fetchWithTimeout(url, 10000); // 10s timeout
+        const res = await fetch(url);
 
         if (!res.ok) {
             // SSR-safe logging

--- a/src/routes/wiki/[slug]/+page.server.js
+++ b/src/routes/wiki/[slug]/+page.server.js
@@ -9,7 +9,7 @@ export async function load({ params, fetch }) {
             `?filter[slug][_eq]=${lemmaSlug}`;
 
         const response = await fetch(url);
-
+        console.log('params.slug:', params.slug);
         if (!response.ok) {
             throw error(500, 'Failed to fetch API');
         }
@@ -29,10 +29,9 @@ export async function load({ params, fetch }) {
                 title: lemma.title,
                 body: lemma.body,
                 address: lemma.address,
-                bouwjaar: lemma.bouwjaar
-            }
+                bouwjaar: lemma.bouwjaar,
+            },
         };
-
     } catch (err) {
         error('Error fetching lemma from API:', err);
 

--- a/src/routes/wiki/[slug]/+page.server.js
+++ b/src/routes/wiki/[slug]/+page.server.js
@@ -1,11 +1,17 @@
 export const prerender = false;
 
 // Helper: fetch with timeout
-async function fetchWithTimeout(url, timeout = 5000) {
+async function fetchWithTimeout(url, timeout = 10000) {
     const controller = new AbortController();
     const id = setTimeout(() => controller.abort(), timeout);
     try {
-        const res = await fetch(url, { signal: controller.signal });
+        const res = await fetch(url, { 
+            signal: controller.signal,
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'SvelteKit-App'
+            }
+        });
         return res;
     } finally {
         clearTimeout(id);
@@ -17,7 +23,7 @@ export async function load({ params }) {
     const url = `https://fdnd-agency.directus.app/items/emibazo_lemma?filter[slug][_eq]=${encodeURIComponent(lemmaSlug)}`;
 
     try {
-        const res = await fetchWithTimeout(url, 5000); // 5s timeout
+        const res = await fetchWithTimeout(url, 10000); // 10s timeout
 
         if (!res.ok) {
             // SSR-safe logging

--- a/src/routes/wiki/[slug]/+page.server.js
+++ b/src/routes/wiki/[slug]/+page.server.js
@@ -1,5 +1,7 @@
 import { error } from '@sveltejs/kit';
 
+export const prerender = false;
+
 export async function load({ params, fetch }) {
     try {
         const lemmaSlug = params.slug;
@@ -33,7 +35,8 @@ export async function load({ params, fetch }) {
             },
         };
     } catch (err) {
-        error('Error fetching lemma from API:', err);
+        // eslint-disable-next-line no-console
+        console.error('Error fetching lemma from API:', err);
 
         // show proper error page instead of 500 crash
         throw error(500, 'Server error while loading lemma');

--- a/src/routes/wiki/[slug]/+page.server.js
+++ b/src/routes/wiki/[slug]/+page.server.js
@@ -2,24 +2,25 @@ import { error } from '@sveltejs/kit';
 
 export const prerender = false;
 
-export async function load({ params, fetch }) {
+export async function load({ params }) {
+    const lemmaSlug = params.slug;
+
+    const url =
+        `https://fdnd-agency.directus.app/items/emibazo_lemma` +
+        `?filter[slug][_eq]=${encodeURIComponent(lemmaSlug)}`;
+
     try {
-        const lemmaSlug = params.slug;
-
-        const url =
-            `https://fdnd-agency.directus.app/items/emibazo_lemma` +
-            `?filter[slug][_eq]=${encodeURIComponent(lemmaSlug)}`;
-
         const response = await fetch(url);
 
+        // If Directus itself fails → real server problem
         if (!response.ok) {
-            throw error(500, 'Failed to fetch API');
+            throw error(response.status, 'Failed to fetch API');
         }
 
         const json = await response.json();
-        const lemma = json.data?.[0];
+        const lemma = json.data?.[0] ?? null;
 
-        // ✅ handle missing slug properly
+        // Proper 404 (allowed — does NOT crash SSR)
         if (!lemma) {
             throw error(404, 'Lemma not found');
         }
@@ -31,14 +32,24 @@ export async function load({ params, fetch }) {
                 title: lemma.title,
                 body: lemma.body,
                 address: lemma.address,
-                bouwjaar: lemma.bouwjaar,
-            },
+                bouwjaar: lemma.bouwjaar
+            }
         };
-    } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error('Error fetching lemma from API:', err);
 
-        // show proper error page instead of 500 crash
-        throw error(500, 'Server error while loading lemma');
+    } catch (err) {
+        // IMPORTANT:
+        // If it's already a SvelteKit HTTP error, rethrow it
+        if (err?.status) {
+            throw err;
+        }
+
+        // eslint-disable-next-line no-console
+        console.error('Directus fetch failed:', err);
+
+        // Instead of crashing SSR with 500,
+        // return safe fallback data
+        return {
+            lemma: null
+        };
     }
 }

--- a/src/routes/wiki/[slug]/+page.server.js
+++ b/src/routes/wiki/[slug]/+page.server.js
@@ -1,11 +1,29 @@
 export const prerender = false;
 
-export async function load({ params, fetch }) {
+// Helper: fetch with timeout
+async function fetchWithTimeout(url, timeout = 10000) {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeout);
+    try {
+        const res = await fetch(url, {
+            signal: controller.signal,
+            headers: {
+                Accept: 'application/json',
+                'User-Agent': 'SvelteKit-App',
+            },
+        });
+        return res;
+    } finally {
+        clearTimeout(id);
+    }
+}
+
+export async function load({ params }) {
     const lemmaSlug = params.slug;
     const url = `https://fdnd-agency.directus.app/items/emibazo_lemma?filter[slug][_eq]=${encodeURIComponent(lemmaSlug)}`;
 
     try {
-        const res = await fetch(url);
+        const res = await fetchWithTimeout(url, 10000); // 10s timeout
 
         if (!res.ok) {
             // SSR-safe logging

--- a/src/routes/wiki/[slug]/+page.server.js
+++ b/src/routes/wiki/[slug]/+page.server.js
@@ -1,43 +1,50 @@
-import { error } from '@sveltejs/kit';
+export const prerender = false;
 
-
-export async function load({ params, fetch }) {
+// Helper: fetch with timeout
+async function fetchWithTimeout(url, timeout = 5000) {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeout);
     try {
-        const lemmaSlug = params.slug;
+        const res = await fetch(url, { signal: controller.signal });
+        return res;
+    } finally {
+        clearTimeout(id);
+    }
+}
 
-        const url =
-            `https://fdnd-agency.directus.app/items/emibazo_lemma` +
-            `?filter[slug][_eq]=${encodeURIComponent(lemmaSlug)}`;
+export async function load({ params }) {
+    const lemmaSlug = params.slug;
+    const url = `https://fdnd-agency.directus.app/items/emibazo_lemma?filter[slug][_eq]=${encodeURIComponent(lemmaSlug)}`;
 
-        const response = await fetch(url);
+    try {
+        const res = await fetchWithTimeout(url, 5000); // 5s timeout
 
-        if (!response.ok) {
-            throw error(500, 'Failed to fetch API');
+        if (!res.ok) {
+            // SSR-safe logging
+              // eslint-disable-next-line no-console
+            console.error(`Directus API error: ${res.status}`);
+            return { lemma: null };
         }
 
-        const json = await response.json();
-        const lemma = json.data?.[0];
-
-        // ✅ handle missing slug properly
-        if (!lemma) {
-            throw error(404, 'Lemma not found');
-        }
+        const json = await res.json();
+        const lemma = json.data?.[0] ?? null;
 
         return {
-            lemma: {
-                lemma: lemma.id,
-                slug: lemma.slug,
-                title: lemma.title,
-                body: lemma.body,
-                address: lemma.address,
-                bouwjaar: lemma.bouwjaar,
-            },
+            lemma: lemma
+                ? {
+                      id: lemma.id,
+                      slug: lemma.slug,
+                      title: lemma.title,
+                      body: lemma.body,
+                      address: lemma.address,
+                      bouwjaar: lemma.bouwjaar,
+                  }
+                : null,
         };
     } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error('Error fetching lemma from API:', err);
-
-        // show proper error page instead of 500 crash
-        throw error(500, 'Server error while loading lemma');
+        // SSR-safe logging
+         // eslint-disable-next-line no-console
+        console.error('SSR fetch failed:', err);
+        return { lemma: null };
     }
 }

--- a/src/routes/wiki/[slug]/+page.server.js
+++ b/src/routes/wiki/[slug]/+page.server.js
@@ -6,10 +6,10 @@ export async function load({ params, fetch }) {
 
         const url =
             `https://fdnd-agency.directus.app/items/emibazo_lemma` +
-            `?filter[slug][_eq]=${lemmaSlug}`;
+            `?filter[slug][_eq]=${encodeURIComponent(lemmaSlug)}`;
 
         const response = await fetch(url);
-        console.log('params.slug:', params.slug);
+
         if (!response.ok) {
             throw error(500, 'Failed to fetch API');
         }

--- a/src/routes/wiki/[slug]/+page.svelte
+++ b/src/routes/wiki/[slug]/+page.svelte
@@ -38,7 +38,10 @@
         <a href="/kaart" class="back-link-kaart">← Terug naar kaart</a>
         <div class="error-message">
             <h1>Lemma niet gevonden</h1>
-            <p>Het gevraagde lemma kon niet worden geladen. Probeer het later opnieuw.</p>
+            <p>
+                Het gevraagde lemma kon niet worden geladen. Probeer het later
+                opnieuw.
+            </p>
         </div>
     </section>
 {/if}

--- a/src/routes/wiki/[slug]/+page.svelte
+++ b/src/routes/wiki/[slug]/+page.svelte
@@ -10,28 +10,38 @@
     <title>Wiki - {lemma?.title ?? 'Wiki'}</title>
 </svelte:head>
 
-<section>
-    <a href="/kaart" class="back-link-kaart">← Terug naar kaart</a>
+{#if lemma}
+    <section>
+        <a href="/kaart" class="back-link-kaart">← Terug naar kaart</a>
 
-    <h1>{lemma.title}</h1>
+        <h1>{lemma.title}</h1>
 
-    <aside>
-        {#if lemma.address}
-            <p><strong>Adres:</strong> {lemma.address}</p>
-        {/if}
+        <aside>
+            {#if lemma.address}
+                <p><strong>Adres:</strong> {lemma.address}</p>
+            {/if}
 
-        {#if lemma.bouwjaar}
-            <p><strong>Bouwjaar:</strong> {lemma.bouwjaar}</p>
-        {/if}
-    </aside>
+            {#if lemma.bouwjaar}
+                <p><strong>Bouwjaar:</strong> {lemma.bouwjaar}</p>
+            {/if}
+        </aside>
 
-    <!-- WIKI INHOUD (body) -->
-    <article>
-        <!-- html tag was getting a warning because of XSS attack but Dompurfiy prevents XSS attack through getting rid of dangorus elements from html and make it more safe for the user to use -->
-        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-        {@html Body}
-    </article>
-</section>
+        <!-- WIKI INHOUD (body) -->
+        <article>
+            <!-- html tag was getting a warning because of XSS attack but Dompurfiy prevents XSS attack through getting rid of dangorus elements from html and make it more safe for the user to use -->
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+            {@html Body}
+        </article>
+    </section>
+{:else}
+    <section>
+        <a href="/kaart" class="back-link-kaart">← Terug naar kaart</a>
+        <div class="error-message">
+            <h1>Lemma niet gevonden</h1>
+            <p>Het gevraagde lemma kon niet worden geladen. Probeer het later opnieuw.</p>
+        </div>
+    </section>
+{/if}
 
 <style>
     :root {
@@ -99,6 +109,18 @@
             width: 80vw;
             background-color: var(--color-secondary);
             height: 2px;
+        }
+    }
+
+    .error-message {
+        text-align: center;
+        padding: var(--spacing-wiki-page);
+        h1 {
+            color: var(--color-error, #e74c3c);
+        }
+        p {
+            margin-top: 1rem;
+            font-size: var(--paragraph-2);
         }
     }
 </style>


### PR DESCRIPTION
lemma error handeling because the error block was duplicate so the reload on localhost worked but on client it crashed

## What does this change?

Resolves issue #1337

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Summary by Sourcery

Verbeter server-side loading en foutafhandeling voor het ophalen van wiki-lemma-pagina's.

Bugfixes:
- Zorg ervoor dat mislukte API-responses en ontbrekende lemma-slugs resulteren in correcte HTTP-fouten in plaats van stille fouten of crashes.
- Uniformeer de foutafhandeling zodat clientnavigatie een passende foutpagina toont in plaats van te crashen wanneer lemma-gegevens niet kunnen worden geladen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve server-side loading and error handling for fetching wiki lemma pages.

Bug Fixes:
- Ensure failed API responses and missing lemma slugs surface as proper HTTP errors instead of silent failures or crashes.
- Unify error handling so client navigation shows an appropriate error page rather than crashing when lemma data cannot be loaded.

</details>